### PR TITLE
viewport tag to render properly

### DIFF
--- a/project/encefal/templates/base.html
+++ b/project/encefal/templates/base.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <title>EnceFAL - {%block pagetitle %}{% endblock pagetitle %}</title>
     <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {% bootstrap_stylesheet_tag %}
     {% bootstrap_stylesheet_tag "responsive" %}
     <!--[if lt IE 9]>


### PR DESCRIPTION
Finalement c'est le manque de l'élément `viewport` qui empêchée le site à s'afficher correctement dans les différentes résolutions.
